### PR TITLE
Also include 'attachment' when sorting SearchWP results

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -619,8 +619,8 @@ function jbaths_postsperpage($limits) {
 
 function my_searchwp_query_orderby() {
 	global $wpdb;
-	return "ORDER BY {$wpdb->prefix}posts.post_type DESC, {$wpdb->prefix}posts.post_date DESC";
-	//return "ORDER BY FIELD({$wpdb->prefix}posts.post_type, 'bathtubs', 'faucets', 'showers', 'toilets', 'post', 'page'), {$wpdb->prefix}posts.post_date DESC";
+	//return "ORDER BY {$wpdb->prefix}posts.post_type DESC, {$wpdb->prefix}posts.post_date DESC";
+	return "ORDER BY FIELD({$wpdb->prefix}posts.post_type, 'bathtubs', 'faucets', 'showers', 'toilets', 'post', 'page', 'attachment'), {$wpdb->prefix}posts.post_date DESC";
 }
 
 add_filter( 'searchwp_query_orderby', 'my_searchwp_query_orderby' );


### PR DESCRIPTION
If any enabled post types (in the search engine settings) are not included in the `ORDER BY` they bubble to the top of the list.